### PR TITLE
Correct node type for hyperlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.idea
+/vendor
+composer.lock
+.DS_Store
+*.code-workspace
+*.phar

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -63,7 +63,7 @@ class Tool
             if ($simple = (self::$simpleNodeList[$node->nodeName] ?? null)) {
                 $nodeParse = new Models\Node($simple, new Models\Unit(), self::getChildElements($node->childNodes, --$max));
             } elseif ($node->nodeName === 'a') {
-                $nodeParse = new Models\Node("a", new Models\Link($node->getAttribute('href')), self::getChildElements($node->childNodes, --$max));
+                $nodeParse = new Models\Node("hyperlink", new Models\Link($node->getAttribute('href')), self::getChildElements($node->childNodes, --$max));
             } elseif (array_key_exists($node->nodeName, self::$textNodeList)) {
                 $nodeParse = new Models\TextNode("text", Encoding::toWin1252($node->nodeValue), new Models\Unit(), self::getMarks($node));
             } else {


### PR DESCRIPTION
Contentful rejects a node type of 'a' and suggests one of the following:

- asset-hyperlink
- embedded-entry-inline
- entry-hyperlink
- hyperlink

This change forces a node type of 'hyperlink'

Signed-off-by: Brendan Bullen <66941+bullenb@users.noreply.github.com>